### PR TITLE
Fix handling

### DIFF
--- a/main.go
+++ b/main.go
@@ -10,15 +10,19 @@ import (
 )
 
 func main() {
-	cfg := newrelic.NewConfig("Gin App", os.Getenv("NEW_RELIC_LICENSE_KEY"))
-	cfg.Logger = newrelic.NewDebugLogger(os.Stdout)
-	app, err := newrelic.NewApplication(cfg)
-	if nil != err {
-		fmt.Println(err)
-		os.Exit(1)
-	}
 	r := gin.Default()
-	r.Use(nrgin.Middleware(app))
+	if os.Getenv("NEWRELIC_LICENSE_KEY") != "" {
+		cfg := newrelic.NewConfig("Gin App", os.Getenv("NEWRELIC_LICENSE_KEY"))
+		cfg.Logger = newrelic.NewDebugLogger(os.Stdout)
+		app, err := newrelic.NewApplication(cfg)
+		if nil != err {
+			fmt.Println(err)
+			os.Exit(1)
+		}
+
+		r.Use(nrgin.Middleware(app))
+	}
+
 
 	r.GET("/ping", func(c *gin.Context) {
 		c.JSON(200, gin.H{


### PR DESCRIPTION
## WHY

- no set Newrelic licence key

```
$ docker run quay.io/koudaiii/newrelic-gin-sample:latest
license length is not 40
```

## WHAT

```
$ bin/newrelic-gin-sample 
[GIN-debug] [WARNING] Running in "debug" mode. Switch to "release" mode in production.
 - using env:	export GIN_MODE=release
 - using code:	gin.SetMode(gin.ReleaseMode)

[GIN-debug] GET    /ping                     --> main.main.func1 (3 handlers)
[GIN-debug] Environment variable PORT is undefined. Using port :8080 by default
[GIN-debug] Listening and serving HTTP on :8080
[GIN] 2017/01/23 - 18:50:26 | 200 |     174.612µs | ::1 |   GET     /ping
```